### PR TITLE
Small improvements

### DIFF
--- a/msftrecon/msftrecon.py
+++ b/msftrecon/msftrecon.py
@@ -557,7 +557,7 @@ class AzureRecon:
 
         # Check OAuth permissions and grants
         try:
-            manifest_url = f"https://{self.ms_login}/{tenant_id}/oauth2/v2.0/authorize?client_id=common&response_type=id_token&scope=openid profile"
+            manifest_url = f"https://{self.ms_login}/{tenant_id}/oauth2/v2.0/authorize?client_id=common&response_type=id_token&scope=openid+profile"
             response = urlopen(Request(manifest_url, headers={"User-agent": "Mozilla/5.0"}))
             if response.status == 200:
                 content = response.read().decode()


### PR DESCRIPTION
Original PR was killed by a previous reformatting commit

Improvements here: 
- Check MDI functions fixed, the `sensor.atp.azure.com` domain does not exist, therefore the function always fails
- Functions merged into the overall class object for better object property support
- Debug mode enabled which allows for more verbose error output (if applicable)
- URL listings for Gov/CN Az tenants, applicable switches via arguments
- typo fix in url arguments